### PR TITLE
style: vertically center presenter layout

### DIFF
--- a/layouts/presenter.vue
+++ b/layouts/presenter.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="bg-main slidev-layout">
-    <div class="flex items-center">
+  <div class="bg-main slidev-layout flex">
+    <div class="flex items-center w-full">
       <figure class="w-1/2">
         <TheDots />
         <img


### PR DESCRIPTION
The `presenter` layout doesn't center the content to the page if the text is not sufficient enough to be aligned along with the image.

Before:
![image](https://user-images.githubusercontent.com/45036724/167247316-410745ac-7f06-4888-8bd2-c93662a4b260.png)

After:
![image](https://user-images.githubusercontent.com/45036724/167247331-3d3b1a1a-2b66-4c4a-9bc0-9981097cf39b.png)
