### PR TITLE
fix: the corner curves overlap the content in default template

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="bg-main slidev-layout" :class="{ grid: $attrs.center }">
     <CornerCurves class="absolute transform bottom-0 right-0 flip-x" />
-    <div class="my-auto z-10">
+    <div class="my-auto z-10 relative">
       <slot />
     </div>
   </div>


### PR DESCRIPTION
![Screenshot_20220518_192922](https://user-images.githubusercontent.com/45036724/169039625-4806c136-36af-416a-99d0-809153d628da.png)

As you can see in above image, the corner curves is positioned above the contents. It is because the `z-10` in the content wrapper does not give an effect due to the unpositioned element. So I added `relative` class and it solved.

```html {2}
<CornerCurves class="absolute transform bottom-0 right-0 flip-x" />
<div class="my-auto z-10 relative">
      <slot />
</div>
```